### PR TITLE
Fix issue "Duplicate transaction on Transact()"

### DIFF
--- a/account.go
+++ b/account.go
@@ -219,7 +219,7 @@ func (account *account) Transact(ctx context.Context, preConditionCheck func() b
 			// There is another transaction with the same nonce and a higher or
 			// equal gas price as that of this transaction.
 			if strings.Compare(err.Error(), core.ErrReplaceUnderpriced.Error()) == 0 {
-				return err
+				return ErrNonceIsOutOfSync
 			}
 			log.Println(err)
 		}

--- a/account.go
+++ b/account.go
@@ -181,7 +181,8 @@ func (account *account) Transact(ctx context.Context, preConditionCheck func() b
 
 	// Keep retrying 'f' until the post-condition check passes or the context
 	// times out.
-	for {
+	var postConPassed = false
+	for !postConPassed {
 		// If context is done, return error
 		select {
 		case <-ctx.Done():
@@ -224,11 +225,23 @@ func (account *account) Transact(ctx context.Context, preConditionCheck func() b
 			continue
 		}
 
+		for i := 0; i <24; i++ {
+			select {
+			case <-ctx.Done():
+				return ErrPostConditionCheckFailed
+			default:
+				if postConditionCheck == nil || postConditionCheck() {
+					postConPassed = true
+				}
+			}
+			if postConPassed {
+				break
+			}
+			time.Sleep(5 * time.Second)
+		}
+
 		// If post-condition check passes, proceed to wait for a specified
 		// number of blocks to be confirmed after the transaction's block
-		if postConditionCheck == nil || postConditionCheck() {
-			break
-		}
 
 		// Wait for sometime before attempting to execute the transaction
 		// again. If context is done, return error to indicate that
@@ -237,7 +250,6 @@ func (account *account) Transact(ctx context.Context, preConditionCheck func() b
 		case <-ctx.Done():
 			return ErrPostConditionCheckFailed
 		case <-time.After(sleepDurationMs * time.Millisecond):
-
 		}
 
 		// Increase delay for next round but saturate at 30s

--- a/account.go
+++ b/account.go
@@ -219,12 +219,12 @@ func (account *account) Transact(ctx context.Context, preConditionCheck func() b
 			// There is another transaction with the same nonce and a higher or
 			// equal gas price as that of this transaction.
 			if strings.Compare(err.Error(), core.ErrReplaceUnderpriced.Error()) == 0 {
-				return g
+				return err
 			}
 			log.Println(err)
 		}
 
-		for i := 0; i < 180 ; i++ {
+		for i := 0; i < 180; i++ {
 			select {
 			case <-ctx.Done():
 				return ErrPostConditionCheckFailed

--- a/account.go
+++ b/account.go
@@ -219,13 +219,12 @@ func (account *account) Transact(ctx context.Context, preConditionCheck func() b
 			// There is another transaction with the same nonce and a higher or
 			// equal gas price as that of this transaction.
 			if strings.Compare(err.Error(), core.ErrReplaceUnderpriced.Error()) == 0 {
-				return ErrNonceIsOutOfSync
+				return g
 			}
 			log.Println(err)
-			continue
 		}
 
-		for i := 0; i <24; i++ {
+		for i := 0; i < 180 ; i++ {
 			select {
 			case <-ctx.Done():
 				return ErrPostConditionCheckFailed
@@ -237,7 +236,7 @@ func (account *account) Transact(ctx context.Context, preConditionCheck func() b
 			if postConPassed {
 				break
 			}
-			time.Sleep(5 * time.Second)
+			time.Sleep(time.Second)
 		}
 
 		// If post-condition check passes, proceed to wait for a specified

--- a/beth_test.go
+++ b/beth_test.go
@@ -74,7 +74,7 @@ var _ = Describe("contracts", func() {
 	read := func(ctx context.Context, conn beth.Client, contract *test.Bethtest) (*big.Int, error) {
 		newVal, err := contract.Read(&bind.CallOpts{})
 		if err != nil {
-			return nil ,err
+			return nil, err
 		}
 		fmt.Printf("[info] Value in contract is %v\n", newVal.String())
 		return newVal, nil
@@ -99,7 +99,7 @@ var _ = Describe("contracts", func() {
 			return newVal.Cmp(val) == 0
 		}
 
-		return  account.Transact(ctx, nil, f, postCondition, waitBlocks)
+		return account.Transact(ctx, nil, f, postCondition, waitBlocks)
 	}
 
 	increment := func(account beth.Account, contract *test.Bethtest, val *big.Int, waitBlocks int64) error {
@@ -122,8 +122,7 @@ var _ = Describe("contracts", func() {
 			return newVal.Cmp(val) >= 0
 		}
 
-		return  account.Transact(ctx, nil, f, postCondition, waitBlocks)
-
+		return account.Transact(ctx, nil, f, postCondition, waitBlocks)
 	}
 
 	appendToList := func(values []*big.Int, contract *test.Bethtest, account beth.Account, waitBlocks int64) []error {
@@ -216,24 +215,9 @@ var _ = Describe("contracts", func() {
 			}
 
 			// Execute delete tx
-			for {
-				sleepFor := 1000
-				err := account.Transact(ctx, preCondition, f, postCondition, waitBlocks)
-				if err != nil && err == beth.ErrNonceIsOutOfSync {
-					sleepFor += 10
-					if sleepFor >= 30000 {
-						sleepFor = 30000
-					}
-					if err := account.ResetToPendingNonce(ctx, time.Duration(sleepFor)); err != nil {
-						errs[i] = err
-						break
-					}
-					continue
-				}
-				errs[i] = err
-				break
-			}
+			errs[i] = account.Transact(ctx, preCondition, f, postCondition, waitBlocks)
 		})
+
 		return errs
 	}
 
@@ -319,14 +303,14 @@ var _ = Describe("contracts", func() {
 						fmt.Printf("\n\x1b[37;1mSetting integer %v in the contract on %s\n\x1b[0m", val.String(), network)
 
 						ethClient := account.EthClient()
-						nonceBefore, err  := ethClient.EthClient().NonceAt(context.Background(), account.Address(),nil)
+						nonceBefore, err := ethClient.EthClient().NonceAt(context.Background(), account.Address(), nil)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						// Set value in the contract
 						err = setInt(account, contract, val, waitBlocks)
 						Expect(err).ShouldNot(HaveOccurred())
 
-						nonceMid, err  := ethClient.EthClient().NonceAt(context.Background(), account.Address(),nil)
+						nonceMid, err := ethClient.EthClient().NonceAt(context.Background(), account.Address(), nil)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(nonceMid - nonceBefore).Should(Equal(uint64(1)))
 
@@ -336,7 +320,7 @@ var _ = Describe("contracts", func() {
 						err = increment(account, contract, val, waitBlocks)
 						Expect(err).ShouldNot(HaveOccurred())
 
-						nonceAfter, err := ethClient.EthClient().NonceAt(context.Background(), account.Address(),nil)
+						nonceAfter, err := ethClient.EthClient().NonceAt(context.Background(), account.Address(), nil)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(nonceAfter - nonceMid).Should(Equal(uint64(1)))
 					}

--- a/beth_test.go
+++ b/beth_test.go
@@ -71,14 +71,14 @@ var _ = Describe("contracts", func() {
 		return
 	}
 
-	read := func(ctx context.Context, conn beth.Client, contract *test.Bethtest) (newVal *big.Int, err error) {
-		err = conn.Get(ctx, func() (err error) {
-			newVal, err = contract.Read(&bind.CallOpts{})
-			return
-		})
+	read := func(ctx context.Context, conn beth.Client, contract *test.Bethtest) ( *big.Int, error) {
+		newVal, err := contract.Read(&bind.CallOpts{})
+		if err != nil {
+			return nil, err
+		}
 
 		fmt.Printf("[info] Value in contract is %v\n", newVal.String())
-		return
+		return newVal, nil
 	}
 
 	setInt := func(account beth.Account, contract *test.Bethtest, val *big.Int, waitBlocks int64) error {


### PR DESCRIPTION
**Description**

This PR is a fix for issue #3. 
Tests have been updated to cover the bug.

**Motivation**

The reason causing duplicate transaction is we only check the post-condition once after sending the transaction. As parity nodes return the transaction receipt immediately and sometimes the blockchain is slow and the tx takes time to be on-chain. Since we retry after failing the post-condition check, it causes sending the same tx more than once.

**Design**

Check post-condition every 5 seconds for 2 mins even after we get the transaction receipt.
This gives enough time to get the tx to be on-chain (assuming it's using fast transaction fee.) 

**Unresolved Issues**
It still can happen if gas price has been set a lower number.
