### PR TITLE
Fix issue 5: panicing in Transact(...) function 

### DIFF
--- a/account.go
+++ b/account.go
@@ -135,6 +135,7 @@ func NewAccount(url string, privateKey *ecdsa.PrivateKey) (Account, error) {
 	}
 	if err := account.updateGasPrice(Fast); err != nil {
 		log.Println(fmt.Sprintf("cannot update gas price = %v", err))
+		account.transactOpts.GasPrice = big.NewInt(11)
 	}
 
 	return account, nil
@@ -207,14 +208,14 @@ func (account *account) Transact(ctx context.Context, preConditionCheck func() b
 			if err != nil {
 				return err
 			}
+			txHash = tx.Hash()
 
-			receipt, err := account.client.WaitMined(innerCtx, tx)
+			_, err = account.client.WaitMined(innerCtx, tx)
 			if err != nil {
 				return err
 			}
 
 			// Transaction did not error, proceed to post-condition checks
-			txHash = receipt.TxHash
 			return nil
 		}(); err != nil {
 			// There is another transaction with the same nonce and a higher or
@@ -503,9 +504,6 @@ func (account *account) retryNonceTx(ctx context.Context, f func(*bind.TransactO
 func (account *account) updateGasPrice(txSpeed TxExecutionSpeed) error {
 	gasPrice, err := SuggestedGasPrice(txSpeed)
 	if err != nil {
-		if account.transactOpts.GasPrice == nil {
-			account.transactOpts.GasPrice = big.NewInt(11)
-		}
 		return err
 	}
 	if gasPrice != nil {

--- a/account.go
+++ b/account.go
@@ -310,15 +310,19 @@ func (account *account) Transfer(ctx context.Context, to common.Address, value *
 
 		transactor := &bind.TransactOpts{
 			From:     transactOpts.From,
-			Nonce:    big.NewInt(0).Set(transactOpts.Nonce),
+			Nonce:    transactOpts.Nonce,
 			Signer:   transactOpts.Signer,
 			Value:    value,
-			GasPrice: big.NewInt(0),
+			GasPrice: transactOpts.GasPrice,
 			GasLimit: 21000,
 			Context:  ctx,
 		}
+
+		if transactOpts.Nonce != nil {
+			transactor.Nonce = big.NewInt(0).Set(transactOpts.Nonce)
+		}
 		if transactOpts.GasPrice != nil {
-			transactor.GasPrice.Set(transactOpts.GasPrice)
+			transactor.GasPrice = big.NewInt(0).Set(transactOpts.Nonce)
 		}
 
 		return bound.Transfer(transactor)
@@ -431,15 +435,18 @@ func (account *account) retryNonceTx(ctx context.Context, f func(*bind.TransactO
 
 	transactor := &bind.TransactOpts{
 		From:     account.transactOpts.From,
-		Nonce:    big.NewInt(0).Set(account.transactOpts.Nonce),
+		Nonce:    account.transactOpts.Nonce,
 		Signer:   account.transactOpts.Signer,
 		Value:    big.NewInt(0),
-		GasPrice: big.NewInt(0),
+		GasPrice: account.transactOpts.GasPrice,
 		GasLimit: account.transactOpts.GasLimit,
 		Context:  ctx,
 	}
+	if account.transactOpts.Nonce != nil {
+		transactor.Nonce = big.NewInt(0).Set(account.transactOpts.Nonce)
+	}
 	if account.transactOpts.GasPrice != nil {
-		transactor.GasPrice.Set(account.transactOpts.GasPrice)
+		transactor.GasPrice = big.NewInt(0).Set(account.transactOpts.GasPrice)
 	}
 
 	tx, err := f(transactor)


### PR DESCRIPTION
**Description**

This PR is a fix for issue #4 and #5. 

**Motivation**
The empty hash is caused by using the receipt to get the txHash which is not reliable when we talking to a parity node.

The panic happens when we try to create a new transactor and set the `gasPrice` with the account transactor's `gasPrice` which can be nil. 

**Design**

For the `txHash`, we use the hash from the tx instead of the receipt.

For the GasPrice, if something wrong happens when we create the account. We use a default `gasPrice` for now. And we'll always check if the `gasPrice` is nil when we're trying to updating it.

