### PR TITLE
Expose the original ethclient along with beth's client

### DIFF
--- a/account.go
+++ b/account.go
@@ -14,13 +14,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/crypto"
-
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
@@ -62,9 +61,9 @@ const (
 // respective private key.
 type Account interface {
 
-	// BethClient returns the client that the account is connected to. Using 
-	// this client, read-only operations can be executed on Ethereum.
-	BethClient() Client
+	// Client that the account is connected to. Using the Client, read-only
+	// operations can be executed on Ethereum.
+	Client() Client
 
 	// EthClient returns the actual Ethereum client.
 	EthClient() *ethclient.Client
@@ -182,7 +181,7 @@ func (account *account) ReadAddress(key string) (common.Address, error) {
 	return common.Address{}, ErrAddressNotFound
 }
 
-func (account *account) BethClient() Client {
+func (account *account) Client() Client {
 	return account.client
 }
 

--- a/account.go
+++ b/account.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 // ErrPreConditionCheckFailed indicates that the pre-condition for executing
@@ -60,7 +61,13 @@ const (
 // to the Ethereum blockchain. An Account is defined by its public address and
 // respective private key.
 type Account interface {
-	EthClient() Client
+
+	// BethClient returns the client that the account is connected to. Using 
+	// this client, read-only operations can be executed on Ethereum.
+	BethClient() Client
+
+	// EthClient returns the actual Ethereum client.
+	EthClient() *ethclient.Client
 
 	// Address returns the ethereum address of the account holder.
 	Address() common.Address
@@ -175,9 +182,12 @@ func (account *account) ReadAddress(key string) (common.Address, error) {
 	return common.Address{}, ErrAddressNotFound
 }
 
-// EthClient returns the ethereum client that the account is connected to.
-func (account *account) EthClient() Client {
+func (account *account) BethClient() Client {
 	return account.client
+}
+
+func (account *account) EthClient() *ethclient.Client {
+	return account.client.EthClient()
 }
 
 // Transact attempts to execute a transaction on the Ethereum blockchain with

--- a/beth_test.go
+++ b/beth_test.go
@@ -60,8 +60,7 @@ var _ = Describe("contracts", func() {
 			return nil, errors.New("invalid infura network")
 		}
 		// Get contract
-		conn := account.EthClient()
-		return test.NewBethtest(contractAddr, bind.ContractBackend(conn.EthClient()))
+		return test.NewBethtest(contractAddr, bind.ContractBackend(account.EthClient()))
 	}
 
 	elementExists := func(ctx context.Context, conn beth.Client, contract *test.Bethtest, val *big.Int) (exists bool) {
@@ -94,7 +93,7 @@ var _ = Describe("contracts", func() {
 
 		// Post-condition: Confirm that the integer has the new value
 		postCondition := func() bool {
-			newVal, err := read(ctx, account.EthClient(), contract)
+			newVal, err := read(ctx, account.BethClient(), contract)
 			if err != nil {
 				return false
 			}
@@ -117,7 +116,7 @@ var _ = Describe("contracts", func() {
 
 		// Post-condition: confirm that previous value has been incremented
 		postCondition := func() bool {
-			newVal, err := read(ctx, account.EthClient(), contract)
+			newVal, err := read(ctx, account.BethClient(), contract)
 			if err != nil {
 				return false
 			}
@@ -141,7 +140,7 @@ var _ = Describe("contracts", func() {
 
 			// Pre-condition: Does element already exist in the list?
 			preCondition := func() bool {
-				exists := elementExists(ctx, account.EthClient(), contract, val)
+				exists := elementExists(ctx, account.BethClient(), contract, val)
 				if exists {
 					fmt.Printf("\n[warning] Element %v exists in list!\n", val.String())
 				}
@@ -156,7 +155,7 @@ var _ = Describe("contracts", func() {
 
 			// Post-condition: Has element been added to the list?
 			postCondition := func() bool {
-				return elementExists(ctx, account.EthClient(), contract, val)
+				return elementExists(ctx, account.BethClient(), contract, val)
 			}
 
 			// Execute transaction
@@ -191,14 +190,14 @@ var _ = Describe("contracts", func() {
 			preCondition := func() bool {
 
 				// Read size of list
-				size, err := size(ctx, account.EthClient(), contract)
+				size, err := size(ctx, account.BethClient(), contract)
 				if err != nil || size.Cmp(big.NewInt(0)) <= 0 {
 					fmt.Println("\n[warning] list is empty!")
 					return false
 				}
 
 				// Check if element is present
-				exists := elementExists(ctx, account.EthClient(), contract, val)
+				exists := elementExists(ctx, account.BethClient(), contract, val)
 				if !exists {
 					fmt.Printf("\n[warning] %v is not present in list!\n", val.String())
 				}
@@ -213,7 +212,7 @@ var _ = Describe("contracts", func() {
 
 			// Post-condition: Has element been deleted successfully?
 			postCondition := func() bool {
-				return !elementExists(ctx, account.EthClient(), contract, val)
+				return !elementExists(ctx, account.BethClient(), contract, val)
 			}
 
 			// Execute delete tx
@@ -315,15 +314,14 @@ var _ = Describe("contracts", func() {
 
 						fmt.Printf("\n\x1b[37;1mSetting integer %v in the contract on %s\n\x1b[0m", val.String(), network)
 
-						ethClient := account.EthClient()
-						nonceBefore, err := ethClient.EthClient().NonceAt(context.Background(), account.Address(), nil)
+						nonceBefore, err := account.EthClient().NonceAt(context.Background(), account.Address(), nil)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						// Set value in the contract
 						err = setInt(account, contract, val, waitBlocks)
 						Expect(err).ShouldNot(HaveOccurred())
 
-						nonceMid, err := ethClient.EthClient().NonceAt(context.Background(), account.Address(), nil)
+						nonceMid, err := account.EthClient().NonceAt(context.Background(), account.Address(), nil)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(nonceMid - nonceBefore).Should(Equal(uint64(1)))
 
@@ -333,7 +331,7 @@ var _ = Describe("contracts", func() {
 						err = increment(account, contract, val, waitBlocks)
 						Expect(err).ShouldNot(HaveOccurred())
 
-						nonceAfter, err := ethClient.EthClient().NonceAt(context.Background(), account.Address(), nil)
+						nonceAfter, err := account.EthClient().NonceAt(context.Background(), account.Address(), nil)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(nonceAfter - nonceMid).Should(Equal(uint64(1)))
 					}
@@ -350,7 +348,7 @@ var _ = Describe("contracts", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					// Retrieve original length of array
-					originalLength, err := size(context.Background(), account.EthClient(), contract)
+					originalLength, err := size(context.Background(), account.BethClient(), contract)
 					Expect(err).ShouldNot(HaveOccurred())
 					fmt.Printf("\n\x1b[37;1mThe size of array on %s is %v\n\x1b[0m", network, originalLength.String())
 
@@ -379,7 +377,7 @@ var _ = Describe("contracts", func() {
 					Expect(err).Should(Equal(beth.ErrPreConditionCheckFailed))
 
 					// Retrieve length of array after deleting the newly added elements
-					newLength, err := size(context.Background(), account.EthClient(), contract)
+					newLength, err := size(context.Background(), account.BethClient(), contract)
 					Expect(err).ShouldNot(HaveOccurred())
 					fmt.Printf("\n\x1b[37;1mThe new size of array on %s is %v\n\x1b[0m", network, newLength.String())
 

--- a/beth_test.go
+++ b/beth_test.go
@@ -93,7 +93,7 @@ var _ = Describe("contracts", func() {
 
 		// Post-condition: Confirm that the integer has the new value
 		postCondition := func() bool {
-			newVal, err := read(ctx, account.BethClient(), contract)
+			newVal, err := read(ctx, account.Client(), contract)
 			if err != nil {
 				return false
 			}
@@ -116,7 +116,7 @@ var _ = Describe("contracts", func() {
 
 		// Post-condition: confirm that previous value has been incremented
 		postCondition := func() bool {
-			newVal, err := read(ctx, account.BethClient(), contract)
+			newVal, err := read(ctx, account.Client(), contract)
 			if err != nil {
 				return false
 			}
@@ -140,7 +140,7 @@ var _ = Describe("contracts", func() {
 
 			// Pre-condition: Does element already exist in the list?
 			preCondition := func() bool {
-				exists := elementExists(ctx, account.BethClient(), contract, val)
+				exists := elementExists(ctx, account.Client(), contract, val)
 				if exists {
 					fmt.Printf("\n[warning] Element %v exists in list!\n", val.String())
 				}
@@ -155,7 +155,7 @@ var _ = Describe("contracts", func() {
 
 			// Post-condition: Has element been added to the list?
 			postCondition := func() bool {
-				return elementExists(ctx, account.BethClient(), contract, val)
+				return elementExists(ctx, account.Client(), contract, val)
 			}
 
 			// Execute transaction
@@ -190,14 +190,14 @@ var _ = Describe("contracts", func() {
 			preCondition := func() bool {
 
 				// Read size of list
-				size, err := size(ctx, account.BethClient(), contract)
+				size, err := size(ctx, account.Client(), contract)
 				if err != nil || size.Cmp(big.NewInt(0)) <= 0 {
 					fmt.Println("\n[warning] list is empty!")
 					return false
 				}
 
 				// Check if element is present
-				exists := elementExists(ctx, account.BethClient(), contract, val)
+				exists := elementExists(ctx, account.Client(), contract, val)
 				if !exists {
 					fmt.Printf("\n[warning] %v is not present in list!\n", val.String())
 				}
@@ -212,7 +212,7 @@ var _ = Describe("contracts", func() {
 
 			// Post-condition: Has element been deleted successfully?
 			postCondition := func() bool {
-				return !elementExists(ctx, account.BethClient(), contract, val)
+				return !elementExists(ctx, account.Client(), contract, val)
 			}
 
 			// Execute delete tx
@@ -348,7 +348,7 @@ var _ = Describe("contracts", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					// Retrieve original length of array
-					originalLength, err := size(context.Background(), account.BethClient(), contract)
+					originalLength, err := size(context.Background(), account.Client(), contract)
 					Expect(err).ShouldNot(HaveOccurred())
 					fmt.Printf("\n\x1b[37;1mThe size of array on %s is %v\n\x1b[0m", network, originalLength.String())
 
@@ -377,7 +377,7 @@ var _ = Describe("contracts", func() {
 					Expect(err).Should(Equal(beth.ErrPreConditionCheckFailed))
 
 					// Retrieve length of array after deleting the newly added elements
-					newLength, err := size(context.Background(), account.BethClient(), contract)
+					newLength, err := size(context.Background(), account.Client(), contract)
 					Expect(err).ShouldNot(HaveOccurred())
 					fmt.Printf("\n\x1b[37;1mThe new size of array on %s is %v\n\x1b[0m", network, newLength.String())
 


### PR DESCRIPTION
Currently, to get the actual Ethereum client from Beth, we need to call EthClient() twice, which can be confusing. This PR converts the existing `EthClient()` method in beth/account.go to `BethClient()` and introduces a new `EthClient()` function to expose the actual Ethereum Client.